### PR TITLE
Fix/update shelf

### DIFF
--- a/src/main/java/com/jordi/booknook/payload/request/UpdateShelfRequest.java
+++ b/src/main/java/com/jordi/booknook/payload/request/UpdateShelfRequest.java
@@ -4,9 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateShelfRequest(
-        @NotBlank String name,
-        @NotBlank String image,
-        @NotBlank String description,
-        @NotNull Boolean public_shelf
+        String name,
+        String image,
+        String description,
+        Boolean public_shelf
 ) {
 }

--- a/src/main/java/com/jordi/booknook/services/ShelfService.java
+++ b/src/main/java/com/jordi/booknook/services/ShelfService.java
@@ -62,10 +62,19 @@ public class ShelfService {
         }
 
         ShelfEntity updatedShelf = shelf.get();
-        updatedShelf.setName(request.name());
-        updatedShelf.setImage(request.image());
-        updatedShelf.setDescription(request.description());
-        updatedShelf.setPublic_shelf(request.public_shelf());
+
+        if (request.name() != null){
+            updatedShelf.setName(request.name());
+        }
+        if (request.image() != null){
+            updatedShelf.setImage(request.image());
+        }
+        if (request.description() != null){
+            updatedShelf.setDescription(request.description());
+        }
+        if (request.public_shelf() != null){
+            updatedShelf.setPublic_shelf(request.public_shelf());
+        }
 
         shelfRepository.save(updatedShelf);
 


### PR DESCRIPTION
Changed the updateShelfById service method to better reflect the PATCH nature of that operation, allowing to get each field from the request or from the actual shelf, so the user can update x number of fields, all fields or no fields.

Also change the request record UpdateShelfRequest to reflect that.