### PR TITLE
Fix setReview guard clause

### DIFF
--- a/src/main/java/com/jordi/booknook/services/BookReviewService.java
+++ b/src/main/java/com/jordi/booknook/services/BookReviewService.java
@@ -93,7 +93,7 @@ public class BookReviewService {
         if (request.rating() != null){
             updatedBookReview.setRating(request.rating());
         }
-        if (request.rating() != null){
+        if (request.review() != null){
             updatedBookReview.setReview(request.review());
         }
 


### PR DESCRIPTION
I was mistakenly checking the rating property of the request. when I should be checking the review property of the request