### PR TITLE
Add test for getBookById GET endpoint.

### DIFF
--- a/src/test/java/com/jordi/booknook/BookControllerTestContainerTest.java
+++ b/src/test/java/com/jordi/booknook/BookControllerTestContainerTest.java
@@ -7,6 +7,8 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import io.restassured.response.ValidatableResponse;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -17,6 +19,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.testcontainers.containers.MySQLContainer;
 
 import java.math.BigDecimal;
@@ -35,10 +41,17 @@ public class BookControllerTestContainerTest {
     static MySQLContainer<?> database =
             new MySQLContainer<>("mysql:8.0.34");
 
+    private static boolean userRegistered = false;
+
     @Autowired
     BookRepository repository;
     @Autowired
     UserRepository userRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+    @Autowired
+    private PlatformTransactionManager transactionManager;
 
     @LocalServerPort
     private Integer port;
@@ -62,21 +75,37 @@ public class BookControllerTestContainerTest {
         registry.add("spring.datasource.password", database::getPassword);
     }
 
+    protected void clearAndResetBooksTable() {
+        TransactionDefinition def = new DefaultTransactionDefinition();
+        TransactionStatus status = transactionManager.getTransaction(def);
+        try {
+            repository.deleteAll();
+            repository.flush();
+            entityManager.createNativeQuery("ALTER TABLE books AUTO_INCREMENT=1").executeUpdate();
+            transactionManager.commit(status);
+        } catch (Exception exception) {
+            transactionManager.rollback(status);
+            throw exception;
+        }
+    }
+
     @BeforeEach
     void setUp() {
         RestAssured.baseURI = "http://localhost:" + port;
-        repository.deleteAll();
-
+        clearAndResetBooksTable();
         // We register a user to use it in auth protected routes.
-        String registerBody = "{\"username\": \"jordi\", \"email\": \"jordi@gmail.com\", \"password\": \"123456\"}";
-        given()
-                .contentType(ContentType.JSON)
-                .body(registerBody)
-                .when()
-                .post("/api/v1/auth/register")
-                .then()
-                .assertThat()
-                .statusCode(HttpStatus.SC_OK);
+        if (!userRegistered) {
+            String registerBody = "{\"username\": \"jordi\", \"email\": \"jordi@gmail.com\", \"password\": \"123456\"}";
+            given()
+                    .contentType(ContentType.JSON)
+                    .body(registerBody)
+                    .when()
+                    .post("/api/v1/auth/register")
+                    .then()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_OK);
+            userRegistered = true;
+        }
 
         // We log in with that recent created user to get the token for auth protected routes.
         String loginBody = "{\"username\": \"jordi\", \"password\": \"123456\"}";
@@ -112,7 +141,6 @@ public class BookControllerTestContainerTest {
                         "Portada 2", "Nuevo libro 3", "Un gran libro 3", price, date, date)
         );
         repository.saveAll(books);
-
         // When: The GET request to retrieve all books is made.
         Response response = given()
                 .headers(headers)
@@ -135,5 +163,41 @@ public class BookControllerTestContainerTest {
                 .body("[0].title", equalTo(books.get(0).getTitle()))
                 .body("[1].title", equalTo(books.get(1).getTitle()))
                 .body("[2].title", equalTo(books.get(2).getTitle()));
+    }
+
+    @Test
+    void getBookShouldReturnABook() {
+        // Given: A valid request with a logged-in user to the GET /api/v1/books/{book-id}/get endpoint.
+        Map<String, String> headers = new HashMap<String, String>() {
+            {
+                put("Accept", "application/json");
+                put("Authorization", "Bearer " + token);
+            }
+        };
+
+        BigDecimal price = new BigDecimal("12.50");
+        LocalDateTime date = LocalDateTime.now();
+
+        BookEntity book = new BookEntity(
+                "Portada", "Nuevo libro test 2", "Un gran libro", price, date, date);
+        repository.save(book);
+
+        // When: The GET request to get a book by id is made.
+        Response response = given()
+                .headers(headers)
+                .contentType(ContentType.JSON)
+                .when()
+                .get("/api/v1/books/1/get");
+
+        // Then: We assert that we get a status code 200 back.
+        response.then()
+                .statusCode(200)
+                .log()
+                .body(true);
+
+
+        // And: We assert that the title of the JSON object is the same as the title of the "book" object.
+        response.then()
+                .body("title", equalTo(book.getTitle()));
     }
 }


### PR DESCRIPTION
Add test for the getBookById GET endpoint.

Assert that the book we save to the DB is the same we get when we call that id, comparing the title.

We also made a couple of changes.

1 - We added a check to the user creation, when the user is created on the first test, it will not register it again causing error in subsequent tests.

2 - We added a clear and reset book table method, that deletes all elements from that table and also sets the AUTO_INCREMENT value to 1, so that when we create new objects in the DB it will always start with id 1, like it would be in a fresh table.

