### PR TITLE
Feature/springdoc swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.2.0</version>
+		</dependency>
+
+		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-impl</artifactId>
 			<version>0.11.5</version>

--- a/src/main/java/com/jordi/booknook/security/SecurityConfig.java
+++ b/src/main/java/com/jordi/booknook/security/SecurityConfig.java
@@ -61,7 +61,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize ->
                         authorize
-                                .requestMatchers("/api/v1/auth/**", "api/v1/shelves/{user_id}/get").permitAll()
+                                .requestMatchers("/api/v1/auth/**", "api/v1/shelves/{user_id}/get",
+                                        "/v3/api-docs/**", "/swagger-ui/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .httpBasic(Customizer.withDefaults());


### PR DESCRIPTION
Add springdoc openapi dependency to the starter.

Config the swagger and openapi JSON routes in the SecurityConfig policies to be open to everyone.