### PR TITLE
Updated Dockerfile, removing unnecessary "mvn clean install" command.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,4 @@ WORKDIR .
 
 COPY . .
 
-RUN mvn clean install -DskipTests
-
 CMD mvn spring-boot:run


### PR DESCRIPTION
[Updated Dockerfile, removing unnecessary "mvn clean install" command.](https://github.com/jfontdev/book-nook-spring/commit/d74de5ba4bc5827ef2c22bb3c80d4c32c50b5173)

We don't need for the moment to do a "mvn clean install", we don't have persitent artifacts, we incrementally compile and then run the spring application via "mvn spring-boot:run". This will speed up the process of building the Docker containers by avoiding the overhead of cleaning and reinstalling dependencies each time.